### PR TITLE
add travis_retry and Python 3.5 to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - python=2.7  CONDA_PY=27  CONDA_NPY=18
     - python=3.3  CONDA_PY=33  CONDA_NPY=18
     - python=3.4  CONDA_PY=34  CONDA_NPY=18
+    - python=3.5  CONDA_PY=35  CONDA_NPY=18
 
   global:
     - secure: "VbVG6isXjRCZeBu9J9NW5xosGfQlHKcuBkjmb8vc2drGjNMP7UctGo5O4fTdF4i70irqfQSUlVGWhgu+OFk4PZ/YadlMydG9z2tF9n0mYzrWxWBmb1EZBcHmwCdG+o52GBWD3VVHOggygx2uFIJJyQCEFHkyU4fdhVnhA+LZeq4="

--- a/continuous-integration/travis/install.sh
+++ b/continuous-integration/travis/install.sh
@@ -1,9 +1,14 @@
 MINICONDA_URL="http://repo.continuum.io/miniconda"
-MINICONDA_FILE="Miniconda-latest-Linux-x86_64.sh"
-wget "${MINICONDA_URL}/${MINICONDA_FILE}"
-bash $MINICONDA_FILE -b
 
-export PATH=$HOME/miniconda/bin:$PATH
-
-conda update --yes conda
-conda install --yes pip conda-build jinja2 binstar
+if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
+    travis_retry wget "${MINICONDA_URL}/Miniconda2-latest-Linux-x86_64.sh" -O miniconda.sh;
+else
+    travis_retry wget "${MINICONDA_URL}/Miniconda3-latest-Linux-x86_64.sh" -O miniconda.sh;
+fi
+chmod +x miniconda.sh
+./miniconda.sh -b -p "${HOME}/miniconda"
+export PATH="${HOME}/miniconda/bin:${PATH}"
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+conda install pip conda-build jinja2 binstar


### PR DESCRIPTION
I've added Python 3.5 to the `.travis.yml` and added some tricks to the `install.sh` that I found across SO and the [conda travis recipe](http://conda.pydata.org/docs/travis.html) itself. Making it more reliable via `travis_retry` and downloading the slightly smaller miniconda2 when possible. Hope it's of use to you.